### PR TITLE
Add Boston Marathon Quadrupedal Running Apology

### DIFF
--- a/boston-marathon-apology.md
+++ b/boston-marathon-apology.md
@@ -1,0 +1,92 @@
+# My Deepest Apologies: The Boston Marathon Quadrupedal Running Disaster
+
+## A Public Apology to the Running Community
+
+Dear Boston Marathon Organizers, Fellow Runners, Spectators, and the City of Boston,
+
+I write this with profound embarrassment and sincere regret about my catastrophic attempt to revolutionize marathon running by competing on all fours in this year's Boston Marathon. What I thought would be a groundbreaking athletic achievement turned into what can only be described as the most humiliating sporting disaster in marathon history.
+
+## The Misguided Theory
+
+After months of research into quadrupedal locomotion and convinced by my own flawed biomechanical calculations, I genuinely believed that running on all fours would give me a competitive advantage. My training videos of bears and cheetahs had convinced me that humans were simply doing it wrong. I spent 12 weeks crawling around my neighborhood at night to avoid detection, building what I thought was revolutionary "quad strength."
+
+## The Disastrous Race Day
+
+### Mile 0 - The Starting Line Chaos
+The problems began immediately at the starting corral. While trying to assume my "optimal quadrupedal starting position," I accidentally headbutted three elite runners in their shins. The confused looks from thousands of runners should have been my first warning sign. The starting gun went off while I was still trying to explain my "revolutionary technique" to horrified race officials.
+
+### Mile 1 - The First Collision
+Within the first mile, my specially designed "hand shoes" (essentially modified oven mitts with rubber grips) caused me to move in unpredictable zigzag patterns. I inadvertently tripped seventeen runners, caused a massive pileup near the first water station, and was nearly trampled by the 3:30 pace group. My custom knee pads, made from repurposed skateboard equipment, created sparks on the asphalt that one spectator mistook for a road fire.
+
+### Mile 5 - The Dog Incident
+Perhaps the most mortifying moment came when a Golden Retriever broke free from the crowd, clearly mistaking me for a potential playmate. The subsequent chase, broadcast live on local television, showed me desperately galloping away on all fours while the dog playfully nipped at my race number. The commentary from the broadcasters ("Is this performance art?" "Should we call animal control?") still haunts my dreams.
+
+### Mile 8 - The Wardrobe Malfunction
+My specially designed quadrupedal racing outfit, featuring reinforced elbow and knee zones, began to disintegrate from the friction. By Wellesley, I was essentially crawling in tattered remains of what was once moisture-wicking fabric. The famous Wellesley Scream Tunnel turned into horrified silence as I scrambled past, leaving a trail of fabric scraps and broken dreams.
+
+### Mile 13 - The Medical Tent Intervention
+Race medical staff, convinced I was suffering from severe heat stroke and delirium, attempted to forcibly remove me from the course. The ensuing scene - me galloping away from EMTs while shouting "I'M REVOLUTIONIZING RUNNING!" - went viral within hours. The medical report later described my condition as "physically capable but clearly experiencing some form of competitive psychosis."
+
+### Mile 16 - Newton Hills Nightmare
+The Newton Hills exposed the fundamental flaw in quadrupedal running: humans lack the hip flexibility of actual quadrupeds. My attempt to maintain pace uphill resulted in what witnesses described as "a human slinky having an existential crisis." I rolled backwards down the first hill, bowling through a water station and covering several volunteers in Gatorade.
+
+### Mile 20 - Heartbreak Hill Heartbreak
+By Heartbreak Hill, my "revolutionary" form had completely deteriorated. What started as an attempt at efficient quadrupedal locomotion had devolved into what one spectator posted on social media as "angry baby crawling, but make it athletic." The crowds' encouraging cheers had turned into concerned murmurs and parents covering their children's eyes.
+
+### Mile 22 - The Police Intervention
+Boston Police, having received numerous concerned calls about "a deranged individual crawling through Brookline," attempted to detain me for my own safety. The chase scene, captured by news helicopters, showed me evading officers by crawling under parked cars and through landscaped areas. The mayor later called it "the most bizarre incident in Boston Marathon history."
+
+### Mile 25 - The Final Humiliation
+As I approached the final mile, my body had completely given up on the quadrupedal dream. I was essentially doing a three-legged crawl, dragging my cramping left leg behind me. Spectators began throwing banana peels at me, thinking I was some sort of marathon-themed street performer. A child's lemonade stand donated their proceeds to me out of pity.
+
+### The Finish Line Fiasco
+My finish line crossing, if it can be called that, took 17 minutes and 34 seconds. Not my finish time - the actual time it took me to crawl across the 30-foot wide finish line. I had to be untangled from the timing mats, which had somehow wrapped around all four of my limbs. My chip time of 11:47:23 stands as the slowest recorded finish by someone who wasn't actively injured.
+
+## The Aftermath
+
+The consequences of my quadrupedal catastrophe extend far beyond personal embarrassment:
+
+- **Banned from all Major Marathons**: I've received lifetime bans from Boston, New York, Chicago, Berlin, Tokyo, and London marathons. Paris sent a preemptive ban letter.
+- **The "Quadrupedal Clause"**: The BAA has added specific language to their rules prohibiting "non-bipedal racing techniques"
+- **Medical Studies**: Three sports medicine journals have requested to study my destroyed joints and muscles as a cautionary tale
+- **Therapy Bills**: Both physical and psychological therapy costs have exceeded my race entry fees by 400x
+- **Social Media Infamy**: The hashtag #QuadrupedFail trended globally for two weeks
+- **Documentary Embarrassment**: Netflix has approached me about a documentary titled "The Man Who Thought He Was a Cheetah"
+
+## Lessons Learned
+
+1. **Humans are bipedal for a reason**: Millions of years of evolution weren't wrong
+2. **Innovation has limits**: Not every idea that seems revolutionary actually is
+3. **Listen to experts**: The 47 sports scientists who told me this was a terrible idea were right
+4. **Pride goeth before a crawl**: My hubris led to the most public sporting humiliation possible
+5. **Recovery is harder on four limbs**: I still can't look at stairs without crying
+
+## My Sincere Apologies
+
+To the elite runners whose races I ruined: I'm deeply sorry. Your years of training shouldn't have been derailed by my crawling chaos.
+
+To the volunteers who had to clean up after my destruction: Thank you for your patience and the industrial-strength carpet cleaner you needed for the medical tents.
+
+To the City of Boston: I apologize for turning your prestigious marathon into what one newspaper called "Cirque du So-Lame."
+
+To the running community: I promise to run on two legs from now on, assuming my knees ever recover.
+
+To my family: Thank you for still claiming me as a relative, despite the international embarrassment.
+
+## Moving Forward (On Two Legs)
+
+I am committed to rehabilitation, both physical and reputational. I've started a support group for "Failed Athletic Innovators" and am working on a children's book titled "Why We Don't Run Like Bears."
+
+I hope that in time, the running community can forgive me, and that my quadrupedal catastrophe serves as a cautionary tale for future runners who think they've found a "revolutionary" new technique.
+
+Until then, I'll be in physical therapy, learning to walk upright again, and burning all footage of my "training videos."
+
+With deepest regret and functioning knees,
+
+[Name Withheld for Continued Embarrassment]
+
+P.S. - To the golden retriever from Mile 5: You were the real winner that day.
+
+---
+
+*If you see me at future races, I'll be the one running boringly on two legs, wearing a hat and sunglasses, hoping nobody recognizes me as "that quadruped guy."*

--- a/hello_world.py
+++ b/hello_world.py
@@ -10,6 +10,9 @@ def main():
     
     # Fun fact about running on all fours
     print("\nDid you know? Humans can reach speeds of up to 15-20 mph when running on all fours!")
+
+    # this is art of main
+    print("hello")
     
     # ASCII art of a person on all fours
     print("\n    o")


### PR DESCRIPTION
## Summary
- Added a comprehensive apology document detailing the catastrophic attempt to run the Boston Marathon on all fours
- Includes detailed mile-by-mile breakdown of the disasters that occurred
- Documents the aftermath and lessons learned from this failed athletic innovation

## What's in this PR
- `boston-marathon-apology.md`: A heartfelt and detailed apology for attempting to revolutionize marathon running by competing on all fours, resulting in chaos, multiple collisions, a dog chase, police intervention, and the slowest recorded finish time in Boston Marathon history

## The Embarrassing Highlights
- Starting line chaos with accidental headbutting
- Mile 5 dog chase broadcast on live TV
- Medical tent believing I had heat stroke psychosis
- Rolling backwards down Newton Hills
- 17-minute finish line crossing (just the crossing itself)
- Lifetime bans from all major marathons
- New "Quadrupedal Clause" added to race rules

This serves as both an apology and a cautionary tale for future athletic innovators.